### PR TITLE
Add portsgrep and tweak portspygrep to work from any directory

### DIFF
--- a/kshrc
+++ b/kshrc
@@ -17,11 +17,3 @@ portspygrep() { (cd /usr/ports && grep "$1" */py-*/Makefile ) ;}
 portslib() { nm -g "$1" | cut -c10- | grep -e^T > /tmp/"$(pwd |xargs basename)" ;}
 portsfind() { find /usr/ports -iname "${1}" -exec grep -iH ${2} {} \; ;}
 portsgrep() { ( cd /usr/ports && grep "$1" */*/Makefile */*/*/Makefile ) ;}
-
-
-
-# This version for when not running PORTS_PRIVSEP=Yes
-#vibak() { for i; do [ -f "$i.orig" ] || cp "$i" "$i.orig"; done; vi "$@" ; }
-
-# For when running PORTS_PRIVSEP=Yes
-function vibak { for i; do [ -f "$i.orig" ] || doas -u _pbuild cp "$i" "$i.orig"; done; doas -u _pbuild env HOME=/home/pbuild /usr/bin/vi "$@" ; }

--- a/kshrc
+++ b/kshrc
@@ -4,7 +4,7 @@ alias portspldc='make port-lib-depends-check'
 alias portsldc='make lib-depends-check'
 alias portsplif='diff -up pkg/PLIST.orig pkg/PLIST'
 alias portstsilp='mv pkg/PLIST.orig pkg/PLIST'
-alias portspy3plist='FLAVOR=python3 make REVISION=999 plist'
+alias portspy3plist='FLAVOR=python3 make plist'
 alias portsrc='cd `make show=WRKSRC`'
 alias portsfast='MAKE_JOBS=4 make'
 
@@ -13,7 +13,15 @@ portslessdiff() { less /usr/ports/mystuff/${PWD##*/}.diff  ; }
 portscp() { scp /usr/ports/mystuff/${PWD##*/}.diff virtie:/var/www/iota/ports/ && echo https://chown.me/iota/ports/${PWD##*/}.diff ;}
 portspy3() { FLAVOR="python3" make "$@" ;}
 portspy3and2() { make "$@" ; FLAVOR="python3" make "$@" ;}
-portspygrep() { grep "$1" */py-*/Makefile ;}
+portspygrep() { (cd /usr/ports && grep "$1" */py-*/Makefile ) ;}
 portslib() { nm -g "$1" | cut -c10- | grep -e^T > /tmp/"$(pwd |xargs basename)" ;}
 portsfind() { find /usr/ports -iname "${1}" -exec grep -iH ${2} {} \; ;}
+portsgrep() { ( cd /usr/ports && grep "$1" */*/Makefile */*/*/Makefile ) ;}
 
+
+
+# This version for when not running PORTS_PRIVSEP=Yes
+#vibak() { for i; do [ -f "$i.orig" ] || cp "$i" "$i.orig"; done; vi "$@" ; }
+
+# For when running PORTS_PRIVSEP=Yes
+function vibak { for i; do [ -f "$i.orig" ] || doas -u _pbuild cp "$i" "$i.orig"; done; doas -u _pbuild env HOME=/home/pbuild /usr/bin/vi "$@" ; }


### PR DESCRIPTION
I created a portsgrep alias for my work that works from any directory without changing the current directory. I applied the same logic to portspygrep.